### PR TITLE
Drop dependency on mingw, use powershell for fb build script instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,13 @@ This is obviously a very early release. I haven't finished cleaning up build pro
 
 You will need the following installed:
 * Git
-* Git Bash (MINGW)
 * Node v12
 * Yarn package manager
 * Visual Studio 2019 (will remove this dependency later)
 
 Steps:
 1. Clone repo to a local directory.
-2. Inside the `fb` directory, run `build.sh` to generate the flatbuffer schema files. This executes flatc.exe, which is included for convenience, but you can of course download the flatbuffer compiler yourself.
+2. Inside the `fb` directory, run `build.ps1` to generate the flatbuffer schema files. This executes flatc.exe, which is included for convenience, but you can of course download the flatbuffer compiler yourself.
 3. Inside the `evevision` directory, run `yarn install`.
 4. Open `overlay-dll/overlay.vcxproj` in Visual Studio and build the project.
 5. Run `yarn dev` inside `/evevision` to start the app in development. Use `yarn package-win` to build a packaged executable, which will be output at `/evevision/release/EveVision VERSION.exe`

--- a/fb/build.ps1
+++ b/fb/build.ps1
@@ -1,0 +1,9 @@
+# This is dumb but I can't get node-gyp to find these files when its called outside of its directory (i.e. when you yarn install on the root project)
+./flatc --cpp --cpp-std c++17 -o output (Get-Item ./*.fbs) --filename-suffix '""'
+
+Remove-Item -Recurse -Force ../overlay-dll/fb -ErrorAction Ignore
+Remove-Item -Recurse -Force ../overlay-node/fb -ErrorAction Ignore
+$null = New-Item -Path ../overlay-dll/fb -ItemType "directory"
+$null = New-Item -Path ../overlay-node/fb -ItemType "directory"
+Copy-Item -Recurse output/* ../overlay-dll/fb
+Copy-Item -Recurse output/* ../overlay-node/fb

--- a/fb/build.sh
+++ b/fb/build.sh
@@ -1,9 +1,0 @@
-# This is dumb but I can't get node-gyp to find these files when its called outside of its directory (i.e. when you yarn install on the root project)
-./flatc --cpp --cpp-std c++17 -o output *.fbs --filename-suffix ""
-
-rm -rf ../overlay-dll/fb
-rm -rf ../overlay-node/fb
-mkdir ../overlay-dll/fb
-mkdir ../overlay-node/fb
-cp -R output/* ../overlay-dll/fb
-cp -R output/* ../overlay-node/fb


### PR DESCRIPTION
Build tested on Win10 PowerShell 6.2.3 (self installed https://aka.ms/pscore6) and 5.1.18362.628 (embedded in windows).

Neither `flatc.exe` nor `libMinHook.x64.lib` is included.