### PR TITLE
Use internal minhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ There is also the native node module that injects the DLL at `/hooker` (which wi
 This is obviously a very early release. I haven't finished cleaning up build processes, especially for open source consumption. There isn't much 'development/production' separation at this time. Even the folder structure is likely to change.
 
 You will need to download two dependencies:
-* libminhook
-* flatc.exe
+* flatc.exe (https://github.com/google/flatbuffers)
 
 You will need the following installed:
 * Python2

--- a/overlay-dll/minhook/hook.c
+++ b/overlay-dll/minhook/hook.c
@@ -31,7 +31,7 @@
 #include <tlhelp32.h>
 #include <limits.h>
 
-#include "../include/MinHook.h"
+#include "MinHook.h"
 #include "buffer.h"
 #include "trampoline.h"
 

--- a/overlay-dll/minhook/trampoline.c
+++ b/overlay-dll/minhook/trampoline.c
@@ -276,7 +276,7 @@ BOOL CreateTrampolineFunction(PTRAMPOLINE ct)
 #ifndef _MSC_VER
         memcpy((LPBYTE)ct->pTrampoline + newPos, pCopySrc, copySize);
 #else
-        __movsb((LPBYTE)ct->pTrampoline + newPos, pCopySrc, copySize);
+        __movsb((LPBYTE)ct->pTrampoline + newPos, (LPBYTE)pCopySrc, copySize);
 #endif
         newPos += copySize;
         oldPos += hs.len;

--- a/overlay-dll/overlay.vcxproj
+++ b/overlay-dll/overlay.vcxproj
@@ -84,7 +84,6 @@
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>libMinHook.x64.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\deps\lib\release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DataExecutionPrevention>true</DataExecutionPrevention>
       <GenerateDebugInformation>false</GenerateDebugInformation>
@@ -128,7 +127,6 @@
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>libMinHook.x64.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\deps\lib\debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DataExecutionPrevention>true</DataExecutionPrevention>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -167,6 +165,26 @@
     <ClCompile Include="graphics\sprites.shader.h" />
     <ClCompile Include="ipc\ipccenter.cc" />
     <ClCompile Include="ipc\ipclink.cc" />
+    <ClCompile Include="minhook\buffer.c">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="minhook\hde\hde32.c">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="minhook\hde\hde64.c">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="minhook\hook.c">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="minhook\trampoline.c">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
     <ClCompile Include="overlay\hookapp.cc" />
     <ClCompile Include="hook\inputhook.cc" />
     <ClCompile Include="main.cpp" />
@@ -209,6 +227,14 @@
     <ClInclude Include="ipc\ipccenter.h" />
     <ClInclude Include="ipc\ipclink.h" />
     <ClInclude Include="ipc\tinyipc.h" />
+    <ClInclude Include="minhook\buffer.h" />
+    <ClInclude Include="minhook\hde\hde32.h" />
+    <ClInclude Include="minhook\hde\hde64.h" />
+    <ClInclude Include="minhook\hde\pstdint.h" />
+    <ClInclude Include="minhook\hde\table32.h" />
+    <ClInclude Include="minhook\hde\table64.h" />
+    <ClInclude Include="minhook\MinHook.h" />
+    <ClInclude Include="minhook\trampoline.h" />
     <ClInclude Include="overlay\hookapp.h" />
     <ClInclude Include="hook\inputhook.h" />
     <ClInclude Include="overlay\overlay.h" />


### PR DESCRIPTION
This will use minhook sources which already were included in the repo but weren't used. With this change there is no longer need to look for minhook binary.