### PR TITLE
add overlay build script

### DIFF
--- a/overlay-dll/build.ps1
+++ b/overlay-dll/build.ps1
@@ -1,0 +1,4 @@
+$vswhere = Join-Path -Path ${env:ProgramFiles(x86)} -ChildPath "Microsoft Visual Studio\Installer\vswhere.exe"
+$msbuild = Invoke-Expression "& '$vswhere' -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe | select-object -first 1"
+
+Invoke-Expression "& '$msbuild' overlay.vcxproj /p:Configuration=Release /p:Platform=x64"


### PR DESCRIPTION
This still requires VS to be installed, however it brings us a step closer to run the whole process in CI/CD pipeline as they usually provide images with VS installed.

This is just primitive sample on how to build it, feel free to reject this PR and build more robust script.